### PR TITLE
Патч библиотеки CURL. Отключил автоматическую переадресацию.

### DIFF
--- a/protected/extensions/telphin/myRequest.php
+++ b/protected/extensions/telphin/myRequest.php
@@ -309,7 +309,7 @@ class myRequest {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+//		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 		curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 		
 	


### PR DESCRIPTION
 Конфликтует с опен_базедир, при этом в нашем случае реально не нужна.